### PR TITLE
Add LightningModule wrapper class from upstream

### DIFF
--- a/src/lightning_graphcore/strategy.py
+++ b/src/lightning_graphcore/strategy.py
@@ -27,7 +27,6 @@ if package_available("lightning"):
     from lightning.fabric.utilities.cloud_io import get_filesystem
     from lightning.pytorch import Trainer
     from lightning.pytorch.accelerators import Accelerator
-    from lightning.pytorch.overrides.base import _LightningModuleWrapperBase
     from lightning.pytorch.plugins.precision import PrecisionPlugin
     from lightning.pytorch.strategies.parallel import ParallelStrategy
     from lightning.pytorch.strategies.strategy import TBroadcast
@@ -44,7 +43,6 @@ elif package_available("pytorch_lightning"):
     from lightning_fabric.utilities.cloud_io import get_filesystem
     from pytorch_lightning import Trainer
     from pytorch_lightning.accelerators import Accelerator
-    from pytorch_lightning.overrides.base import _LightningModuleWrapperBase
     from pytorch_lightning.plugins.precision import PrecisionPlugin
     from pytorch_lightning.strategies.parallel import ParallelStrategy
     from pytorch_lightning.strategies.strategy import TBroadcast
@@ -59,6 +57,7 @@ else:
     raise ModuleNotFoundError("You are missing `lightning` or `pytorch-lightning` package, please install it.")
 
 from lightning_graphcore.accelerator import _IPU_AVAILABLE, _POPTORCH_AVAILABLE
+from lightning_graphcore.utils import _LightningModuleWrapperBase
 
 if _POPTORCH_AVAILABLE:
     import poptorch

--- a/src/lightning_graphcore/utils.py
+++ b/src/lightning_graphcore/utils.py
@@ -21,8 +21,7 @@ from lightning.pytorch.overrides.base import _LightningPrecisionModuleWrapperBas
 
 class _LightningModuleWrapperBase(_DeviceDtypeModuleMixin, torch.nn.Module):
     def __init__(self, forward_module: Union["pl.LightningModule", _LightningPrecisionModuleWrapperBase]) -> None:
-        """Wrap the user's LightningModule and redirect the forward call to the appropriate method, either
-        ``training_step``, ``validation_step``, ``test_step``, or ``predict_step``.
+        """Wrap the user's LightningModule and redirect the forward call to the appropriate `*_step()` methods.
 
         Inheriting classes may also modify the inputs or outputs of forward.
 

--- a/src/lightning_graphcore/utils.py
+++ b/src/lightning_graphcore/utils.py
@@ -21,7 +21,7 @@ from lightning.pytorch.overrides.base import _LightningPrecisionModuleWrapperBas
 
 class _LightningModuleWrapperBase(_DeviceDtypeModuleMixin, torch.nn.Module):
     def __init__(self, forward_module: Union["pl.LightningModule", _LightningPrecisionModuleWrapperBase]) -> None:
-        """Wraps the user's LightningModule and redirects the forward call to the appropriate method, either
+        """Wrap the user's LightningModule and redirect the forward call to the appropriate method, either
         ``training_step``, ``validation_step``, ``test_step``, or ``predict_step``.
 
         Inheriting classes may also modify the inputs or outputs of forward.

--- a/src/lightning_graphcore/utils.py
+++ b/src/lightning_graphcore/utils.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 from typing import Any, Union
 
-import torch
-
 import lightning.pytorch as pl
+import torch
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
 from lightning.pytorch.overrides.base import _LightningPrecisionModuleWrapperBase
 
 
 class _LightningModuleWrapperBase(_DeviceDtypeModuleMixin, torch.nn.Module):
-
     def __init__(self, forward_module: Union["pl.LightningModule", _LightningPrecisionModuleWrapperBase]) -> None:
         """Wraps the user's LightningModule and redirects the forward call to the appropriate method, either
         ``training_step``, ``validation_step``, ``test_step``, or ``predict_step``.
+
         Inheriting classes may also modify the inputs or outputs of forward.
+
         Args:
             forward_module: The module to wrap. If it's not a LightningModule, it must have an attribute ``.module``
                 pointing to a LightningModule reference.

--- a/src/lightning_graphcore/utils.py
+++ b/src/lightning_graphcore/utils.py
@@ -14,9 +14,8 @@
 from typing import Any, Union
 
 import lightning.pytorch as pl
-from lightning_utilities.core.imports import package_available
-
 import torch
+from lightning_utilities.core.imports import package_available
 
 if package_available("lightning"):
     from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin

--- a/src/lightning_graphcore/utils.py
+++ b/src/lightning_graphcore/utils.py
@@ -14,9 +14,16 @@
 from typing import Any, Union
 
 import lightning.pytorch as pl
+from lightning_utilities.core.imports import package_available
+
 import torch
-from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
-from lightning.pytorch.overrides.base import _LightningPrecisionModuleWrapperBase
+
+if package_available("lightning"):
+    from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
+    from lightning.pytorch.overrides.base import _LightningPrecisionModuleWrapperBase
+elif package_available("pytorch_lightning"):
+    from pytorch_lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
+    from pytorch_lightning.overrides.base import _LightningPrecisionModuleWrapperBase
 
 
 class _LightningModuleWrapperBase(_DeviceDtypeModuleMixin, torch.nn.Module):

--- a/src/lightning_graphcore/utils.py
+++ b/src/lightning_graphcore/utils.py
@@ -1,0 +1,74 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Union
+
+import torch
+
+import lightning.pytorch as pl
+from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
+from lightning.pytorch.overrides.base import _LightningPrecisionModuleWrapperBase
+
+
+class _LightningModuleWrapperBase(_DeviceDtypeModuleMixin, torch.nn.Module):
+
+    def __init__(self, forward_module: Union["pl.LightningModule", _LightningPrecisionModuleWrapperBase]) -> None:
+        """Wraps the user's LightningModule and redirects the forward call to the appropriate method, either
+        ``training_step``, ``validation_step``, ``test_step``, or ``predict_step``.
+        Inheriting classes may also modify the inputs or outputs of forward.
+        Args:
+            forward_module: The module to wrap. If it's not a LightningModule, it must have an attribute ``.module``
+                pointing to a LightningModule reference.
+        """
+        super().__init__()
+        if not isinstance(forward_module, pl.LightningModule) and (
+            not isinstance(getattr(forward_module, "module", None), pl.LightningModule)
+        ):
+            raise ValueError(
+                "`forward_module` must be a `LightningModule` instance or have an attribute `.module` pointing to one,"
+                f" got: {forward_module.__class__.__qualname__}"
+            )
+        self._forward_module = forward_module
+
+        # set the parameters_to_ignore from LightningModule.
+        _ddp_params_and_buffers_to_ignore = getattr(self._forward_module, "_ddp_params_and_buffers_to_ignore", [])
+        self._ddp_params_and_buffers_to_ignore = [f"module.{p}" for p in _ddp_params_and_buffers_to_ignore]
+
+    @property
+    def lightning_module(self) -> "pl.LightningModule":
+        if isinstance(self._forward_module, pl.LightningModule):
+            return self._forward_module
+        return self._forward_module.module
+
+    def forward(self, *inputs: Any, **kwargs: Any) -> Any:
+        pl_module = self.lightning_module
+        trainer = pl_module._trainer
+
+        if trainer is not None:
+            if trainer.training:
+                output = self._forward_module.training_step(*inputs, **kwargs)
+                # In manual_optimization, we need to prevent DDP reducer as
+                # it is done manually in `LightningModule.manual_backward`
+                # `require_backward_grad_sync` will be reset in the
+                # ddp_strategy `post_training_step` hook
+                if not pl_module.automatic_optimization:
+                    assert trainer.model is not None
+                    trainer.model.require_backward_grad_sync = False  # type: ignore[assignment]
+                return output
+            if trainer.testing:
+                return self._forward_module.test_step(*inputs, **kwargs)
+            if trainer.sanity_checking or trainer.validating:
+                return self._forward_module.validation_step(*inputs, **kwargs)
+            if trainer.predicting:
+                return self._forward_module.predict_step(*inputs, **kwargs)
+        return self._forward_module(*inputs, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+from unittest.mock import Mock
+
+from lightning_utilities.core.imports import package_available
+
+if package_available("lightning"):
+    from lightning.pytorch.demos.boring_classes import BoringModel
+elif package_available("pytorch_lightning"):
+    from pytorch_lightning.demos.boring_classes import BoringModel
+
+from lightning_graphcore.utils import _LightningModuleWrapperBase
+
+
+def test_wrapper():
+    trainer = Mock()
+    model = Mock(spec=BoringModel)
+    model._trainer = trainer
+    wrapped_model = _LightningModuleWrapperBase(model)
+
+    trainer.training = True
+    wrapped_model.forward()
+    model.training_step.assert_called_once()
+
+    trainer.training = False
+    trainer.testing = True
+    wrapped_model.forward()
+    model.test_step.assert_called_once()
+
+    trainer.testing = False
+    trainer.validating = True
+    wrapped_model.forward()
+    model.validation_step.assert_called_once()
+
+    trainer.validating = False
+    trainer.sanity_checking = True
+    wrapped_model.forward()
+    model.validation_step.assert_called()
+
+    trainer.sanity_checking = False
+    trainer.predicting = True
+    wrapped_model.forward()
+    model.predict_step.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,12 +2,12 @@ from unittest.mock import Mock
 
 from lightning_utilities.core.imports import package_available
 
+from lightning_graphcore.utils import _LightningModuleWrapperBase
+
 if package_available("lightning"):
     from lightning.pytorch.demos.boring_classes import BoringModel
 elif package_available("pytorch_lightning"):
     from pytorch_lightning.demos.boring_classes import BoringModel
-
-from lightning_graphcore.utils import _LightningModuleWrapperBase
 
 
 def test_wrapper():


### PR DESCRIPTION
Adds backward compatibility for the changes introduced in https://github.com/Lightning-AI/lightning/pull/17531


<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
