### PR TITLE
Half precision

### DIFF
--- a/_requirements/test.txt
+++ b/_requirements/test.txt
@@ -1,7 +1,7 @@
 coverage>=5.0
 pytest>=6.0
 pytest-cov
-mypy==1.1.1
+mypy==1.2.0
 
 scikit-learn>0.22.1, <1.2.3
 torchmetrics>=0.8.0, <0.12.0

--- a/src/lightning_graphcore/precision.py
+++ b/src/lightning_graphcore/precision.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Literal, Union, cast
+from typing import Any, Callable, List, Literal, Tuple, Union, cast
 
 from lightning_utilities.core.imports import package_available
 from torch import Tensor
 from torch.nn import Module
 from torch.optim import LBFGS, Optimizer
 from typing_extensions import get_args
-from typing import List, Tuple
 
 if package_available("lightning"):
     from lightning.fabric.utilities.types import Optimizable

--- a/src/lightning_graphcore/precision.py
+++ b/src/lightning_graphcore/precision.py
@@ -70,7 +70,6 @@ class IPUPrecision(PrecisionPlugin):
     def connect(
         self, model: Module, optimizers: List[Optimizer], lr_schedulers: List[Any]
     ) -> Tuple[Module, List[Optimizer], List[Any]]:
-        """Connects this plugin to the accelerator and the training process."""
         model = self.convert_module(model)
         return super().connect(model, optimizers, lr_schedulers)
 

--- a/src/lightning_graphcore/precision.py
+++ b/src/lightning_graphcore/precision.py
@@ -51,7 +51,7 @@ class IPUPrecision(PrecisionPlugin):
 
     Raises:
         ValueError:
-            If the precision is neither 16-mixed nor 32-true.
+            If the precision is neither 16-true, 16-mixed nor 32-true.
     """
 
     def __init__(self, precision: Literal["32-true", "16-mixed", "16-true"]) -> None:

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -206,6 +206,46 @@ def test_pure_half_precision(tmpdir):
         trainer.fit(model)
 
 
+def test_true_half_precision(tmpdir):
+    class TestCallback(Callback):
+        def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+            assert trainer.strategy.precision_plugin.precision == "16-true"
+            for param in trainer.strategy.model.parameters():
+                assert param.dtype == torch.float16
+            raise SystemExit
+
+    model = IPUModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        fast_dev_run=True,
+        strategy=IPUStrategy(accelerator=IPUAccelerator(), precision_plugin=IPUPrecision("16-true")),
+        devices=1,
+        callbacks=TestCallback(),
+    )
+
+    assert isinstance(trainer.strategy, IPUStrategy)
+    assert isinstance(trainer.strategy.precision_plugin, IPUPrecision)
+    assert trainer.strategy.precision_plugin.precision == "16-true"
+
+    # TODO uncomment
+    # changed_dtypes = [torch.float, torch.float64]
+    # data = [torch.zeros((1), dtype=dtype) for dtype in changed_dtypes]
+    # new_data = trainer.strategy.batch_to_device(data)
+    # assert all(val.dtype is torch.half for val in new_data), "".join(
+    #     [f"{dtype}: {val.dtype}" for dtype, val in zip(changed_dtypes, new_data)]
+    # )
+
+    not_changed_dtypes = [torch.uint8, torch.int8, torch.int32, torch.int64]
+    data = [torch.zeros((1), dtype=dtype) for dtype in not_changed_dtypes]
+    new_data = trainer.strategy.batch_to_device(data)
+    assert all(val.dtype is dtype for val, dtype in zip(new_data, not_changed_dtypes)), "".join(
+        [f"{dtype}: {val.dtype}" for dtype, val in zip(not_changed_dtypes, new_data)]
+    )
+
+    with pytest.raises(SystemExit):
+        trainer.fit(model)
+
+
 def test_device_iterations_ipu_strategy(tmpdir):
     class TestCallback(Callback):
         def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:


### PR DESCRIPTION
## What does this PR do?
Allows training the model in 16-true precision when using the IPU.
The model weights are cast in `Fabric.convert_module` method and when using a Lighting Trainer the previous method is called inside `PrecisionPlugin.connect`.

Fixes # (issue).
[#17655 ](https://github.com/Lightning-AI/lightning/issues/17655) but only for the IPU.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?
Had a good time digging through the structure of Lightning and Fabric. Also the Lightning team was really helpful and gave a lot of guidance. Thanks for that!
