### PR TITLE
Avoid importing protected API from lightning

### DIFF
--- a/src/lightning_graphcore/strategy.py
+++ b/src/lightning_graphcore/strategy.py
@@ -30,7 +30,6 @@ if package_available("lightning"):
     from lightning.pytorch.plugins.precision import PrecisionPlugin
     from lightning.pytorch.strategies.parallel import ParallelStrategy
     from lightning.pytorch.strategies.strategy import TBroadcast
-    from lightning.pytorch.strategies.utils import _fp_to_half
     from lightning.pytorch.trainer.states import RunningStage, TrainerFn
     from lightning.pytorch.utilities import rank_zero_warn
     from lightning.pytorch.utilities.data import _get_dataloader_init_args_and_kwargs, _reinstantiate_wrapped_cls
@@ -46,7 +45,6 @@ elif package_available("pytorch_lightning"):
     from pytorch_lightning.plugins.precision import PrecisionPlugin
     from pytorch_lightning.strategies.parallel import ParallelStrategy
     from pytorch_lightning.strategies.strategy import TBroadcast
-    from pytorch_lightning.strategies.utils import _fp_to_half
     from pytorch_lightning.trainer.states import RunningStage, TrainerFn
     from pytorch_lightning.utilities import rank_zero_warn
     from pytorch_lightning.utilities.data import _get_dataloader_init_args_and_kwargs, _reinstantiate_wrapped_cls
@@ -57,7 +55,7 @@ else:
     raise ModuleNotFoundError("You are missing `lightning` or `pytorch-lightning` package, please install it.")
 
 from lightning_graphcore.accelerator import _IPU_AVAILABLE, _POPTORCH_AVAILABLE
-from lightning_graphcore.utils import _LightningModuleWrapperBase
+from lightning_graphcore.utils import _LightningModuleWrapperBase, _fp_to_half
 
 if _POPTORCH_AVAILABLE:
     import poptorch

--- a/src/lightning_graphcore/strategy.py
+++ b/src/lightning_graphcore/strategy.py
@@ -55,7 +55,7 @@ else:
     raise ModuleNotFoundError("You are missing `lightning` or `pytorch-lightning` package, please install it.")
 
 from lightning_graphcore.accelerator import _IPU_AVAILABLE, _POPTORCH_AVAILABLE
-from lightning_graphcore.utils import _LightningModuleWrapperBase, _fp_to_half
+from lightning_graphcore.utils import _fp_to_half, _LightningModuleWrapperBase
 
 if _POPTORCH_AVAILABLE:
     import poptorch

--- a/src/lightning_graphcore/utils.py
+++ b/src/lightning_graphcore/utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Union, Literal
+from typing import Any, Literal, Union
 
 import torch
 from lightning_utilities.core.imports import package_available


### PR DESCRIPTION
The strategy imports protected APIs from Lightning, which is blocking the CI in https://github.com/Lightning-AI/lightning/pull/18217

This PR moves the definitions here.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
